### PR TITLE
Allow list items to be targeted by index

### DIFF
--- a/lib/template.dart
+++ b/lib/template.dart
@@ -3,6 +3,7 @@ part of mustache;
 final Object _NO_SUCH_PROPERTY = new Object();
 
 final RegExp _validTag = new RegExp(r'^[0-9a-zA-Z\_\-\.]+$');
+final RegExp _integerTag = new RegExp(r'^[0-9]+$');
 
 Template _parse(String source, {bool lenient : false}) {
 	var tokens = _scan(source, lenient);
@@ -150,6 +151,9 @@ class _Template implements Template {
 		var property = null;
 		if (object is Map && object.containsKey(name)) {
 			return object[name];
+		}
+		if (object is List && _integerTag.hasMatch(name)) {
+			return object[int.parse(name)];
 		}
 		if (_lenient && !_validTag.hasMatch(name)) {
 			return _NO_SUCH_PROPERTY;


### PR DESCRIPTION
This allows templates to access list items by index, as discussed in https://github.com/janl/mustache.js/issues/158. 

Example usage: {{#myList.0}} {{/myList.0}}
