### PR TITLE
Added examples copied from README, fixed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ main() {
 	  {{/ names }}
 	  {{! I am a comment. }}
 	''';
-	
+
 	var template = new Template(source, name: 'template-filename.html');
-	
+
 	var output = template.renderString({'names': [
 		{'firstname': 'Greg', 'lastname': 'Lowe'},
 		{'firstname': 'Bob', 'lastname': 'Johnson'}
 	]});
-	
+
 	print(output);
 }
 ```
@@ -86,8 +86,8 @@ var output = t.renderString({'foo': 'bar'}); // bar
 
 ```dart
 var t = new Template('{{# foo }}');
-var lambda = (_) => 'bar'};
-t.renderString({'foo': lambda); // bar
+var lambda = (_) => 'bar';
+t.renderString({'foo': lambda}); // bar
 ```
 
 ```dart
@@ -98,20 +98,20 @@ t.renderString({'foo': lambda); // shown
 
 ```dart
 var t = new Template('{{# foo }}oi{{/ foo }}');
-var lambda = (LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>'};
-t.renderString({'foo': lambda); // <b>OI</b>
+var lambda = (LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
+t.renderString({'foo': lambda}); // <b>OI</b>
 ```
 
 ```dart
 var t = new Template('{{# foo }}{{bar}}{{/ foo }}');
-var lambda = (LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>'};
-t.renderString({'foo': lambda, 'bar': 'pub'); // <b>PUB</b>
+var lambda = (LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
+t.renderString({'foo': lambda, 'bar': 'pub'}); // <b>PUB</b>
 ```
 
 ```dart
 var t = new Template('{{# foo }}{{bar}}{{/ foo }}');
-var lambda = (LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>'};
-t.renderString({'foo': lambda, 'bar': 'pub'); // <b>PUB</b>
+var lambda = (LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
+t.renderString({'foo': lambda, 'bar': 'pub'}); // <b>PUB</b>
 ```
 
 In the following example `LambdaContext.renderSource(source)` re-parses the source string in the current context, this is the default behaviour in many mustache implementations. Since re-parsing the content is slow, and often not required, this library makes this step optional.
@@ -119,5 +119,5 @@ In the following example `LambdaContext.renderSource(source)` re-parses the sour
 ```dart
 var t = new Template('{{# foo }}{{bar}}{{/ foo }}');
 var lambda = (LambdaContext ctx) => ctx.renderSource(ctx.source + '{{cmd}}')};
-t.renderString({'foo': lambda, 'bar': 'pub', 'cmd': 'build'); // pub build
+t.renderString({'foo': lambda, 'bar': 'pub', 'cmd': 'build'}); // pub build
 ```

--- a/example/basic.dart
+++ b/example/basic.dart
@@ -1,0 +1,22 @@
+import 'package:mustache/mustache.dart';
+
+main() {
+  var source = '''
+    {{# names }}
+          <div>{{ lastname }}, {{ firstname }}</div>
+    {{/ names }}
+    {{^ names }}
+      <div>No names.</div>
+    {{/ names }}
+    {{! I am a comment. }}
+  ''';
+
+  var template = new Template(source, name: 'template-filename.html');
+
+  var output = template.renderString({'names': [
+      {'firstname': 'Greg', 'lastname': 'Lowe'},
+      {'firstname': 'Bob', 'lastname': 'Johnson'}
+  ]});
+
+  print(output);
+}

--- a/example/lambdas.dart
+++ b/example/lambdas.dart
@@ -1,0 +1,33 @@
+import 'package:mustache/mustache.dart';
+
+main() {
+  var t = new Template('{{ foo }}');
+  var lambda = (_) => 'bar';
+  var output = t.renderString({'foo': lambda}); // bar
+  print(output);
+
+  t = new Template('{{# foo }}hidden{{/ foo }}');
+  lambda = (_) => 'shown';
+  output = t.renderString({'foo': lambda}); // shown
+  print(output);
+
+  t = new Template('{{# foo }}oi{{/ foo }}');
+  lambda = (LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
+  output = t.renderString({'foo': lambda}); // <b>OI</b>
+  print(output);
+
+  t = new Template('{{# foo }}{{bar}}{{/ foo }}');
+  lambda = (LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
+  output = t.renderString({'foo': lambda, 'bar': 'pub'}); // <b>PUB</b>
+  print(output);
+
+  t = new Template('{{# foo }}{{bar}}{{/ foo }}');
+  lambda = (LambdaContext ctx) => '<b>${ctx.renderString().toUpperCase()}</b>';
+  output = t.renderString({'foo': lambda, 'bar': 'pub'}); // <b>PUB</b>
+  print(output);
+
+  t = new Template('{{# foo }}{{bar}}{{/ foo }}');
+  lambda = (LambdaContext ctx) => ctx.renderSource(ctx.source + '{{cmd}}');
+  output = t.renderString({'foo': lambda, 'bar': 'pub', 'cmd': 'build'}); // pub build
+  print(output);
+}

--- a/example/nested_paths.dart
+++ b/example/nested_paths.dart
@@ -1,0 +1,7 @@
+import 'package:mustache/mustache.dart';
+
+main() {
+  var template = new Template('{{ author.name }}');
+  var output = template.renderString({'author': {'name': 'Greg Lowe'}});
+  print(output);
+}

--- a/example/partials.dart
+++ b/example/partials.dart
@@ -1,0 +1,16 @@
+import 'package:mustache/mustache.dart';
+
+main() {
+  var partial = new Template('{{ foo }}', name: 'partial');
+
+  var resolver = (String name) {
+     if (name == 'partial-name') { // Name of partial tag.
+       return partial;
+     }
+  };
+
+  var t = new Template('{{> partial-name }}', partialResolver: resolver);
+
+  var output = t.renderString({'foo': 'bar'}); // bar
+  print(output);
+}


### PR DESCRIPTION
@xxgreg This library became clearer to me when I pulled out your helpful examples from the README. So I thought it would help others to just have them in an example folder.  Also, I fixed a bit of syntax error in the README examples.  Thank you for making this!