### PR TITLE
Allow arbitrary objects for truthiness checks in lenient mode, run dartf...

### DIFF
--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -166,6 +166,10 @@ class Renderer extends Visitor {
        context.close();        
        if (output != null) write(output);
        
+     } else if (lenient) {
+       // We consider all other values as 'true' in lenient mode.
+       _renderWithValue(node, null);
+
      } else {
        throw error('Invalid value type for section, '
          'section: ${node.name}, '
@@ -196,6 +200,10 @@ class Renderer extends Visitor {
        // Do nothing.
         //TODO in strict mode should this be an error?
    
+     } else if (lenient) {
+       // We consider all other values as 'true' in lenient mode. Since this
+       // is an inverted section, we do nothing.
+
      } else {
        throw error(
          'Invalid value type for inverse section, '

--- a/test/mustache_test.dart
+++ b/test/mustache_test.dart
@@ -55,6 +55,11 @@ main() {
 			expect(ex is TemplateException, isTrue);
 			expect(ex.message, startsWith(BAD_VALUE_SECTION));
 		});
+		test('Invalid value - lenient mode', () {
+			var output = parse('{{#var}}_{{var}}_{{/var}}', lenient: true)
+          .renderString({'var' : 42});
+			expect(output, equals('_42_'));
+		});
 
 		test('True', () {
 			var output = parse('{{#section}}_ok_{{/section}}')
@@ -224,6 +229,11 @@ Empty.
 				{"section": 42});
 			expect(ex is TemplateException, isTrue);
 			expect(ex.message, startsWith(BAD_VALUE_INV_SECTION));
+		});
+		test('Invalid value - lenient mode', () {
+			var output = parse('{{^var}}_ok_{{/var}}', lenient: true)
+          .renderString({'var' : 42});
+			expect(output, equals(''));
 		});
 		test('True', () {
 			var output = parse('{{^section}}_ok_{{/section}}')


### PR DESCRIPTION
This aligns the dart implementation slightly with the python implementation of mustache (which allows arbitrary values to be used in sections). It is also very convenient to be able to say

```
{{#package}}The package is {{package}} - yes!{{/package}}
```

and render it with `{'package' : 'my package name'}`.