### PR TITLE
Fixing strong mode errors

### DIFF
--- a/lib/src/lambda_context.dart
+++ b/lib/src/lambda_context.dart
@@ -11,11 +11,9 @@ import 'template_exception.dart';
 class LambdaContext implements m.LambdaContext {
   final Node _node;
   final Renderer _renderer;
-  final bool _isSection;
   bool _closed = false;
 
-  LambdaContext(this._node, this._renderer, {bool isSection: true})
-      : _isSection = isSection;
+  LambdaContext(this._node, this._renderer);
 
   void close() {
     _closed = true;
@@ -72,7 +70,9 @@ class LambdaContext implements m.LambdaContext {
 
     if (nodes.isEmpty) return '';
 
-    if (nodes.length == 1 && nodes.first is TextNode) return nodes.first.text;
+    if (nodes.length == 1 && nodes.first is TextNode) {
+      return (nodes.single as TextNode).text;
+    }
 
     return _renderer.source.substring(node.contentStart, node.contentEnd);
   }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -42,7 +42,7 @@ class Parser {
         _delimiters = delimiters,
         _lenient = lenient,
         _scanner =
-            new Scanner(source, templateName, delimiters, lenient: lenient);
+            new Scanner(source, templateName, delimiters);
 
   final String _source;
   final bool _lenient;
@@ -146,7 +146,7 @@ class Parser {
     if (children.isEmpty || children.last is! TextNode) {
       children.add(new TextNode(token.value, token.start, token.end));
     } else {
-      var last = children.removeLast();
+      var last = children.removeLast() as TextNode;
       var node = new TextNode(last.text + token.value, last.start, token.end);
       children.add(node);
     }

--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -90,7 +90,7 @@ class Renderer extends Visitor {
     var value = resolveValue(node.name);
 
     if (value is Function) {
-      var context = new LambdaContext(node, this, isSection: false);
+      var context = new LambdaContext(node, this);
       value = value(context);
       context.close();
     }
@@ -132,7 +132,7 @@ class Renderer extends Visitor {
       if (!lenient) throw error(
           'Value was missing for section tag: ${node.name}.', node);
     } else if (value is Function) {
-      var context = new LambdaContext(node, this, isSection: true);
+      var context = new LambdaContext(node, this);
       var output = value(context);
       context.close();
       if (output != null) write(output);
@@ -258,7 +258,7 @@ class Renderer extends Visitor {
   m.TemplateException error(String message, Node node) =>
       new TemplateException(message, templateName, source, node.start);
 
-  static const Map<String, String> _htmlEscapeMap = const {
+  static const Map<int, String> _htmlEscapeMap = const {
     _AMP: '&amp;',
     _LT: '&lt;',
     _GT: '&gt;',

--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -4,10 +4,8 @@ import 'token.dart';
 import 'template_exception.dart';
 
 class Scanner {
-  Scanner(String source, this._templateName, String delimiters,
-      {bool lenient: true})
+  Scanner(String source, this._templateName, String delimiters)
       : _source = source,
-        _lenient = lenient,
         _itr = source.runes.iterator {
     if (source == '') {
       _c = _EOF;
@@ -35,7 +33,6 @@ class Scanner {
 
   final String _templateName;
   final String _source;
-  final bool _lenient;
 
   final Iterator<int> _itr;
   int _offset = 0;

--- a/test/mustache_specs.dart
+++ b/test/mustache_specs.dart
@@ -46,7 +46,9 @@ _defineGroupFromFile(filename, text) {
     //Make sure that we reset the state of the Interpolation - Multiple Calls test
     //as for some reason dart can run the group more than once causing the test
     //to fail the second time it runs
-    tearDown(() => lambdas['Interpolation - Multiple Calls'].reset());
+    tearDown(() {
+      (lambdas['Interpolation - Multiple Calls'] as _DummyCallableWithState).reset();
+    });
 
     tests.forEach((t) {
       var testDescription = new StringBuffer(t['name']);

--- a/test/mustache_test.dart
+++ b/test/mustache_test.dart
@@ -448,7 +448,7 @@ Empty.
     String _partialTest(Map values, Map sources, String renderTemplate,
         {bool lenient: false}) {
       var templates = new Map<String, Template>();
-      var resolver = (name) => templates[name];
+      var resolver = (String name) => templates[name];
       for (var k in sources.keys) {
         templates[k] = new Template(sources[k],
             name: k, lenient: lenient, partialResolver: resolver);

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -10,14 +10,14 @@ main() {
   group('Scanner', () {
     test('scan text', () {
       var source = 'abc';
-      var scanner = new Scanner(source, 'foo', '{{ }}', lenient: false);
+      var scanner = new Scanner(source, 'foo', '{{ }}');
       var tokens = scanner.scan();
       expectTokens(tokens, [new Token(TokenType.text, 'abc', 0, 3)]);
     });
 
     test('scan tag', () {
       var source = 'abc{{foo}}def';
-      var scanner = new Scanner(source, 'foo', '{{ }}', lenient: false);
+      var scanner = new Scanner(source, 'foo', '{{ }}');
       var tokens = scanner.scan();
       expectTokens(tokens, [
         new Token(TokenType.text, 'abc', 0, 3),
@@ -30,7 +30,7 @@ main() {
 
     test('scan tag whitespace', () {
       var source = 'abc{{ foo }}def';
-      var scanner = new Scanner(source, 'foo', '{{ }}', lenient: false);
+      var scanner = new Scanner(source, 'foo', '{{ }}');
       var tokens = scanner.scan();
       expectTokens(tokens, [
         new Token(TokenType.text, 'abc', 0, 3),
@@ -45,7 +45,7 @@ main() {
 
     test('scan tag sigil', () {
       var source = 'abc{{ # foo }}def';
-      var scanner = new Scanner(source, 'foo', '{{ }}', lenient: false);
+      var scanner = new Scanner(source, 'foo', '{{ }}');
       var tokens = scanner.scan();
       expectTokens(tokens, [
         new Token(TokenType.text, 'abc', 0, 3),
@@ -62,7 +62,7 @@ main() {
 
     test('scan tag dot', () {
       var source = 'abc{{ foo.bar }}def';
-      var scanner = new Scanner(source, 'foo', '{{ }}', lenient: false);
+      var scanner = new Scanner(source, 'foo', '{{ }}');
       var tokens = scanner.scan();
       expectTokens(tokens, [
         new Token(TokenType.text, 'abc', 0, 3),
@@ -79,7 +79,7 @@ main() {
 
     test('scan triple mustache', () {
       var source = 'abc{{{foo}}}def';
-      var scanner = new Scanner(source, 'foo', '{{ }}', lenient: false);
+      var scanner = new Scanner(source, 'foo', '{{ }}');
       var tokens = scanner.scan();
       expectTokens(tokens, [
         new Token(TokenType.text, 'abc', 0, 3),
@@ -92,7 +92,7 @@ main() {
 
     test('scan triple mustache whitespace', () {
       var source = 'abc{{{ foo }}}def';
-      var scanner = new Scanner(source, 'foo', '{{ }}', lenient: false);
+      var scanner = new Scanner(source, 'foo', '{{ }}');
       var tokens = scanner.scan();
       expectTokens(tokens, [
         new Token(TokenType.text, 'abc', 0, 3),
@@ -107,7 +107,7 @@ main() {
 
     test('scan tag with equals', () {
       var source = '{{foo=bar}}';
-      var scanner = new Scanner(source, 'foo', '{{ }}', lenient: true);
+      var scanner = new Scanner(source, 'foo', '{{ }}');
       var tokens = scanner.scan();
       expectTokens(tokens, [
         new Token(TokenType.openDelimiter, '{{', 0, 2),
@@ -118,7 +118,7 @@ main() {
 
     test('scan comment with equals', () {
       var source = '{{!foo=bar}}';
-      var scanner = new Scanner(source, 'foo', '{{ }}', lenient: false);
+      var scanner = new Scanner(source, 'foo', '{{ }}');
       var tokens = scanner.scan();
       expectTokens(tokens, [
         new Token(TokenType.openDelimiter, '{{', 0, 2),
@@ -161,7 +161,7 @@ main() {
         new SectionNode('foo', 3, 11, '{{ }}'),
         new TextNode('ghi', 22, 25)
       ]);
-      expectNodes(nodes[1].children, [new TextNode('def', 11, 14)]);
+      expectNodes((nodes[1] as SectionNode).children, [new TextNode('def', 11, 14)]);
     });
 
     test('parse section standalone tag whitespace', () {
@@ -173,7 +173,7 @@ main() {
         new SectionNode('foo', 4, 12, '{{ }}'),
         new TextNode('ghi', 26, 29)
       ]);
-      expectNodes(nodes[1].children, [new TextNode('def\n', 13, 17)]);
+      expectNodes((nodes[1] as SectionNode).children, [new TextNode('def\n', 13, 17)]);
     });
 
     test('parse section standalone tag whitespace consecutive', () {
@@ -186,7 +186,7 @@ main() {
         new SectionNode('foo', 26, 34, '{{ }}'),
         new TextNode('ghi', 48, 51),
       ]);
-      expectNodes(nodes[1].children, [new TextNode('def\n', 13, 17)]);
+      expectNodes((nodes[1] as SectionNode).children, [new TextNode('def\n', 13, 17)]);
     });
 
     test('parse section standalone tag whitespace on first line', () {
@@ -197,7 +197,7 @@ main() {
         new SectionNode('foo', 2, 10, '{{ }}'),
         new TextNode('ghi', 26, 29)
       ]);
-      expectNodes(nodes[0].children, [new TextNode('def\n', 13, 17)]);
+      expectNodes((nodes[0] as SectionNode).children, [new TextNode('def\n', 13, 17)]);
     });
 
     test('parse section standalone tag whitespace on last line', () {
@@ -205,7 +205,7 @@ main() {
       var parser = new Parser(source, 'foo', '{{ }}', lenient: false);
       var nodes = parser.parse();
       expectNodes(nodes, [new SectionNode('foo', 0, 8, '{{ }}')]);
-      expectNodes(nodes[0].children, [new TextNode('def\n', 8, 12)]);
+      expectNodes((nodes[0] as SectionNode).children, [new TextNode('def\n', 8, 12)]);
     });
 
     test('parse variable newline', () {
@@ -228,7 +228,7 @@ main() {
         new SectionNode('foo', 5, 13, '{{ }}'),
         new TextNode('ghi', 27, 30)
       ]);
-      expectNodes(nodes[1].children, [new TextNode('def\n', 14, 18)]);
+      expectNodes((nodes[1] as SectionNode).children, [new TextNode('def\n', 14, 18)]);
     });
 
     test('parse whitespace', () {
@@ -253,13 +253,13 @@ main() {
       var source = '{{= | | =}}<|#lambda|-|/lambda|>';
       var parser = new Parser(source, 'foo', '{{ }}', lenient: false);
       var nodes = parser.parse();
-      expect(nodes[1].delimiters, equals('| |'));
       expectNodes(nodes, [
         new TextNode('<', 11, 12),
         new SectionNode('lambda', 12, 21, '| |'),
         new TextNode('>', 31, 32),
       ]);
-      expectNodes(nodes[1].children, [new TextNode('-', 21, 22)]);
+      expect((nodes[1] as SectionNode).delimiters, equals('| |'));
+      expectNodes((nodes[1] as SectionNode).children, [new TextNode('-', 21, 22)]);
     });
 
     test('corner case strict', () {


### PR DESCRIPTION
This involved a few fixes:

* Us `as` a lot, like in places where a Node is definitely a TextNode, and we want to call `.text` on it.
* Remove Scanner's unused `lenient` parameter.
* Remove LambdaContext's unused `isSection` parameter.

Because of those two removes, this PR does include breaking changes, and might justify a big version bump.

Tests pass.

See static analysis and strong errors with `dartanalyzer --strong lib/ test/*.dart`