### PR TITLE
Avoid invocation of Object.

### DIFF
--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -91,7 +91,8 @@ class Renderer extends Visitor {
 
     if (value is Function) {
       var context = new LambdaContext(node, this);
-      value = value(context);
+      Function valueFunction = value;
+      value = valueFunction(context);
       context.close();
     }
 


### PR DESCRIPTION
In Dart 2.0, it will become a compile-time error to try to perform a
function invocation on a variable whose static type is `Object` (see
https://github.com/dart-lang/sdk/issues/31509).  Since `value` is
changed inside the `if` block, it is not type promoted, so its type is
considered to be `Object`.  Therefore, to avoid a compile-time error,
we need to use an intermediate variable of type Function.