### PR TITLE
Add support for class members in sections

### DIFF
--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -139,15 +139,9 @@ class Renderer extends Visitor {
       var output = value(context);
       context.close();
       if (output != null) write(output);
-    } else if (lenient) {
-      // We consider all other values as 'true' in lenient mode.
-      _renderWithValue(node, null);
     } else {
-      throw error(
-          'Invalid value type for section, '
-          'section: ${node.name}, '
-          'type: ${value.runtimeType}.',
-          node);
+      // Assume the value might have accessible member values via mirrors.
+      _renderWithValue(node, value);
     }
   }
 
@@ -249,7 +243,7 @@ class Renderer extends Visitor {
     if ((field is VariableMirror) ||
         ((field is MethodMirror) && (field.isGetter))) {
       invocation = instance.getField(field.simpleName);
-    } else if ((field is MethodMirror) && (field.parameters.length == 0)) {
+    } else if ((field is MethodMirror) && (field.parameters.where((p) => !p.isOptional).length == 0)) {
       invocation = instance.invoke(field.simpleName, []);
     }
     if (invocation == null) {

--- a/test/mustache_specs.dart
+++ b/test/mustache_specs.dart
@@ -32,7 +32,7 @@ defineTests() {
     if (f is File) {
       var filename = f.path;
       if (shouldRun(filename)) {
-        var text = f.readAsStringSync(encoding: UTF8);
+        var text = f.readAsStringSync(encoding: utf8);
         _defineGroupFromFile(filename, text);
       }
     }
@@ -40,8 +40,8 @@ defineTests() {
 }
 
 _defineGroupFromFile(filename, text) {
-  var json = JSON.decode(text);
-  var tests = json['tests'];
+  var jsondata = json.decode(text);
+  var tests = jsondata['tests'];
   filename = filename.substring(filename.lastIndexOf('/') + 1);
   group("Specs of $filename", () {
 

--- a/test/mustache_test.dart
+++ b/test/mustache_test.dart
@@ -15,6 +15,25 @@ const UNCLOSED_TAG = 'Unclosed tag';
 Template parse(String source, {bool lenient: false}) =>
     new Template(source, lenient: lenient);
 
+class NestedVarClass {
+  final String foo;
+  NestedVarClass(this.foo);
+}
+
+class NestedSectionClass {
+  final NestedVarClass v;
+  NestedSectionClass(this.v);
+}
+
+class SectionClass {
+  final NestedSectionClass section;
+  SectionClass(this.section);
+}
+
+class ClassWithOptionalParamMethod {
+  String myMethod([String value = 'hello']) => value;
+}
+
 main() {
   group('Basic', () {
     test('Variable', () {
@@ -55,7 +74,11 @@ main() {
     test('Invalid value', () {
       var ex = renderFail('{{#section}}_{{var}}_{{/section}}', {"section": 42});
       expect(ex is TemplateException, isTrue);
-      expect(ex.message, startsWith(BAD_VALUE_SECTION));
+      expect(ex.message, startsWith(VALUE_MISSING));
+    });
+    test('Nested classes', () {
+      var output = parse('{{#section}}_{{v.foo}}_{{/section}}').renderString(SectionClass(NestedSectionClass(NestedVarClass('hello'))));
+      expect(output, equals('_hello_'));
     });
     test('Invalid value - lenient mode', () {
       var output = parse('{{#var}}_{{var}}_{{/var}}', lenient: true)


### PR DESCRIPTION
I have put some work into a port of [dart-lang/dartdoc](https://github.com/dart-lang/dartdoc) to mustache from mustache4dart, since the latter has been having some trouble getting a stable Dart 2 version out.

To make dartdoc work with mustache, I'd need this PR to add support for members of classes in sections.  Otherwise, the library seems stable and fast and I'd be excited to complete the port once a mustache version is published with this or a similar PR!