### PR TITLE
Remove unused element and dead return

### DIFF
--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -352,26 +352,13 @@ const int _NEWLINE = 10;
 const int _RETURN = 13;
 const int _SPACE = 32;
 const int _EXCLAIM = 33;
-const int _QUOTE = 34;
-const int _APOS = 39;
 const int _HASH = 35;
 const int _AMP = 38;
 const int _PERIOD = 46;
 const int _FORWARD_SLASH = 47;
-const int _LT = 60;
 const int _EQUAL = 61;
 const int _GT = 62;
 const int _CARET = 94;
 
 const int _OPEN_MUSTACHE = 123;
 const int _CLOSE_MUSTACHE = 125;
-
-const int _A = 65;
-const int _Z = 90;
-const int _a = 97;
-const int _z = 122;
-const int _0 = 48;
-const int _9 = 57;
-
-const int _UNDERSCORE = 95;
-const int _MINUS = 45;

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -306,7 +306,6 @@ main() {
         var parser = new Parser(source, 'foo', '{{ }}', lenient: false);
         parser.parse();
         fail('Did not throw.');
-        return null;
       } catch (ex, st) {
         if (ex is! TemplateException) {
           print(ex);


### PR DESCRIPTION
There are many unused elements in scanner.dart.

Also the return statement after `fail` is dead code, as `fail` is marked as `@alwaysThrows`.